### PR TITLE
Update octokit function name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export default async function labelsPlugin(options: Options) {
     ...existingLabels.filter(label => uncheckedLabels.indexOf(label) === -1),
   ].filter((item, pos, ar) => ar.indexOf(item) === pos) as string[]
 
-  await api.issues.replaceAllLabels({
+  await api.issues.replaceLabels({
     ...issue,
     labels: replacementLabels,
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,19 +76,19 @@ export default async function labelsPlugin(options: Options) {
   }) as Rule[]
 
   const api = danger.github.api
-  let issue = { number: 0, repo: "", owner: "" }
+  let issue = { issue_number: 0, repo: "", owner: "" }
   const existingLabels = danger.github.issue.labels.map(({ name }) => name)
   let text = ""
   // PR
   if (danger.github.thisPR) {
     const pr = danger.github.thisPR
     text = danger.github.pr.body
-    issue = { number: pr.number, repo: pr.repo, owner: pr.owner }
+    issue = { issue_number: pr.number, repo: pr.repo, owner: pr.owner }
     // Issue
   } else {
     const gh = danger.github as any
     text = gh.issue.body
-    issue = { number: gh.issue.number, repo: gh.repository.name, owner: gh.repository.owner.login }
+    issue = { issue_number: gh.issue.number, repo: gh.repository.name, owner: gh.repository.owner.login }
   }
 
   const matchingLabels = getCheckedBoxes(text)


### PR DESCRIPTION
In [this PR](https://github.com/octokit/rest.js/pull/1094) Oktokit renamed the function from `replaceAllLabels` to `replaceLabels`. You can also see that in the docs [here](https://octokit.github.io/rest.js/#octokit-routes-issues-replace-labels).

Here I have:
1) Fixed deprecated function `replaceAllLabels`.
2) Fixed deprecated parameter `number`.

Let me know if you need anything else from me but I'd love for this to get updated so I can use this plugin to add labels!